### PR TITLE
fix: Github webhooks being handled by custom scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A new MS Teams adapter for Hubot",
   "main": "index.mjs",
   "scripts": {
-    "test": "node --test",
+    "test": "node --test --test-timeout=10000",
     "start": "node --watch --env-file=.env node_modules/.bin/hubot -f ./index.mjs -n test-bot"
   },
   "repository": {

--- a/src/MsTeamsAdapter.mjs
+++ b/src/MsTeamsAdapter.mjs
@@ -174,7 +174,8 @@ class MsTeamsAdapter extends Adapter {
             this.robot.logger.debug(`body: ${JSON.stringify(req.body)}`)
             next()
         })
-        this.robot.router.post(['/', '/api/messages'], async (req, res)=>{
+
+        this.robot.router.post('/api/messages', async (req, res)=>{
             const robotName = (this.robot.alias == false ? undefined : this.robot.alias) ?? this.robot.name
             // The text coming from Teams looks something like <at>test-bot</at> if it's
             // directed to a user. We need to convert that to @test-bot for Hubot to


### PR DESCRIPTION
Fixes #15 

When a custom script is handling a Github Webhook (HTTP POSTs), the adapter shouldn't be getting that message too.